### PR TITLE
Subtraction, the `-` operator, with a bool tensor is not supported af…

### DIFF
--- a/torchgeometry/conversions.py
+++ b/torchgeometry/conversions.py
@@ -352,9 +352,9 @@ def rotation_matrix_to_quaternion(rotation_matrix, eps=1e-6):
     t3_rep = t3.repeat(4, 1).t()
 
     mask_c0 = mask_d2 * mask_d0_d1
-    mask_c1 = mask_d2 * (1 - mask_d0_d1)
-    mask_c2 = (1 - mask_d2) * mask_d0_nd1
-    mask_c3 = (1 - mask_d2) * (1 - mask_d0_nd1)
+    mask_c1 = mask_d2 * ~(mask_d0_d1)
+    mask_c2 = ~(mask_d2) * mask_d0_nd1
+    mask_c3 = ~(mask_d2) * ~(mask_d0_nd1)
     mask_c0 = mask_c0.view(-1, 1).type_as(q0)
     mask_c1 = mask_c1.view(-1, 1).type_as(q1)
     mask_c2 = mask_c2.view(-1, 1).type_as(q2)


### PR DESCRIPTION
…ter Pytorch 1.7.1

Replaces the `-` operator with the `~` or `logical_not()` operator